### PR TITLE
Pull request: fixed the deployment errors, ai was utilized

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ The main `tsconfig.json` **excludes** the `tests/` tree so `next build` (includi
 
 ## Deploy (e.g. Vercel)
 
+For branch-based preview testing, push your feature branch (for example `kaidendo`) and deploy that branch in Vercel before merging to `main`.
+
 1. **Vercel → Project → Settings → Environment Variables** (Production at minimum):
    - `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` (same as local).
    - `NEXT_PUBLIC_SITE_URL` = your live origin, e.g. `https://mental-health-webapp-sigma.vercel.app` (no trailing slash).  

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "@types/react-dom": "^19",
         "@vitest/coverage-v8": "^3.2.4",
         "eslint": "^9",
-        "eslint-config-next": "^15.3.1",
+        "eslint-config-next": "15.3.8",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
         "typescript": "^5",
@@ -1410,9 +1410,9 @@
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.3.1.tgz",
-      "integrity": "sha512-oEs4dsfM6iyER3jTzMm4kDSbrQJq8wZw5fmT6fg2V3SMo+kgG+cShzLfEV20senZzv8VF+puNLheiGPlBGsv2A==",
+      "version": "15.3.8",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.3.8.tgz",
+      "integrity": "sha512-CKpvDZhNXPUjUHmjHddcsqjwj46oQblFms2hr2uA79C0kVTiSXQEQxkawUsDNSofHhTI31IbSeBdVyuk/U1nKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5808,13 +5808,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.3.1.tgz",
-      "integrity": "sha512-GnmyVd9TE/Ihe3RrvcafFhXErErtr2jS0JDeCSp3vWvy86AXwHsRBt0E3MqP/m8ACS1ivcsi5uaqjbhsG18qKw==",
+      "version": "15.3.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.3.8.tgz",
+      "integrity": "sha512-s/imi0g/LQZsXif8RhlwhgryyqyMhEIMkUL0Yvj0l16ByEAqve4wodS8al+bt+utxf68fgfb1EXlOpuZKqOjlg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "15.3.1",
+        "@next/eslint-plugin-next": "15.3.8",
         "@rushstack/eslint-patch": "^1.10.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@types/react-dom": "^19",
     "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9",
-    "eslint-config-next": "^15.3.1",
+    "eslint-config-next": "15.3.8",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5",


### PR DESCRIPTION
#### Summary
Added a docs update in README.md clarifying that feature branches (e.g. kaidendo) can be deployed in Vercel preview before merging to main.
Pinned eslint-config-next to 15.3.8 in package.json (was ^15.3.1) to align with the patched Next.js toolchain.
Updated package-lock.json to lock related Next lint packages to patched versions (eslint-config-next@15.3.8 and @next/eslint-plugin-next@15.3.8) so Vercel installs secure versions consistently.
#### Why
Vercel deployment logs showed builds running with Next.js 15.3.1, which is flagged as vulnerable.
This change makes the branch explicitly use patched Next.js-related dependencies and avoids the vulnerable version path during deployment.